### PR TITLE
Simplify config validation

### DIFF
--- a/core/src/main/java/org/openconnectors/config/Config.java
+++ b/core/src/main/java/org/openconnectors/config/Config.java
@@ -41,5 +41,4 @@ public interface Config {
     Object getObject(final String propertyName, final Object defaultValue);
 
     Set<String> getPropertyKeys();
-
 }

--- a/core/src/main/java/org/openconnectors/config/ConfigUtils.java
+++ b/core/src/main/java/org/openconnectors/config/ConfigUtils.java
@@ -7,4 +7,10 @@ public class ConfigUtils {
             throw new IllegalArgumentException("Required property '" + key + "' not set.");
         }
     }
+
+    public static void verifyExists(final Config config, final String... keys) {
+        for (String key : keys) {
+            verifyExists(config, key);
+        }
+    }
 }

--- a/kafka010/src/main/java/org/openconnectors/kafka/KafkaSink010.java
+++ b/kafka010/src/main/java/org/openconnectors/kafka/KafkaSink010.java
@@ -24,6 +24,7 @@ import org.apache.kafka.clients.producer.Producer;
 import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.openconnectors.config.Config;
+import org.openconnectors.config.ConfigUtils;
 import org.openconnectors.connect.ConnectorContext;
 import org.openconnectors.connect.SinkConnector;
 import org.openconnectors.util.KeyValue;
@@ -34,8 +35,6 @@ import java.io.IOException;
 import java.util.Collection;
 import java.util.Properties;
 import java.util.concurrent.CompletableFuture;
-
-import static org.openconnectors.config.ConfigUtils.verifyExists;
 
 /**
  * Simple Kafka Sink to publish string messages to a topic
@@ -82,12 +81,14 @@ public class KafkaSink010<K, V> implements SinkConnector<KeyValue<K, V>> {
 
     @Override
     public void open(Config config) throws Exception {
-
-        verifyExists(config, ConfigKeys.KAFKA_SINK_TOPIC);
-        verifyExists(config, ConfigKeys.KAFKA_SINK_BOOTSTRAP_SERVERS);
-        verifyExists(config, ConfigKeys.KAFKA_SINK_ACKS);
-        verifyExists(config, ConfigKeys.KAFKA_SINK_BATCH_SIZE);
-        verifyExists(config, ConfigKeys.KAFKA_SINK_MAX_REQUEST_SIZE);
+        ConfigUtils.verifyExists(
+                config,
+                ConfigKeys.KAFKA_SINK_TOPIC,
+                ConfigKeys.KAFKA_SINK_BOOTSTRAP_SERVERS,
+                ConfigKeys.KAFKA_SINK_ACKS,
+                ConfigKeys.KAFKA_SINK_BATCH_SIZE,
+                ConfigKeys.KAFKA_SINK_MAX_REQUEST_SIZE
+        );
 
         topic = config.getString(ConfigKeys.KAFKA_SINK_TOPIC);
         props.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, config.getString(ConfigKeys.KAFKA_SINK_BOOTSTRAP_SERVERS));

--- a/kafka010/src/main/java/org/openconnectors/kafka/KafkaSource010.java
+++ b/kafka010/src/main/java/org/openconnectors/kafka/KafkaSource010.java
@@ -25,6 +25,7 @@ import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.consumer.ConsumerRecords;
 import org.apache.kafka.clients.consumer.KafkaConsumer;
 import org.openconnectors.config.Config;
+import org.openconnectors.config.ConfigUtils;
 import org.openconnectors.connect.ConnectorContext;
 import org.openconnectors.connect.PushSourceConnector;
 import org.slf4j.Logger;
@@ -36,8 +37,6 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 import java.util.Properties;
-
-import static org.openconnectors.config.ConfigUtils.verifyExists;
 
 /**
  * Simple Kafka Source to emit strng messages from a topic
@@ -55,14 +54,16 @@ public class KafkaSource010<V> implements PushSourceConnector<V> {
 
     @Override
     public void open(Config config) throws Exception {
-
-        verifyExists(config, ConfigKeys.KAFKA_SOURCE_TOPIC);
-        verifyExists(config, ConfigKeys.KAFKA_SINK_BOOTSTRAP_SERVERS);
-        verifyExists(config, ConfigKeys.KAFKA_SOURCE_GROUP_ID);
-        verifyExists(config, ConfigKeys.KAFKA_SOURCE_FETCH_MIN_BYTES);
-        verifyExists(config, ConfigKeys.KAFKA_SOURCE_AUTO_COMMIT_INTERVAL_MS);
-        verifyExists(config, ConfigKeys.KAFKA_SOURCE_SESSION_TIMEOUT_MS);
-        verifyExists(config, ConfigKeys.KAFKA_SOURCE_AUTO_COMMIT_ENABLED);
+        ConfigUtils.verifyExists(
+                config,
+                ConfigKeys.KAFKA_SOURCE_TOPIC,
+                ConfigKeys.KAFKA_SINK_BOOTSTRAP_SERVERS,
+                ConfigKeys.KAFKA_SOURCE_GROUP_ID,
+                ConfigKeys.KAFKA_SOURCE_FETCH_MIN_BYTES,
+                ConfigKeys.KAFKA_SOURCE_AUTO_COMMIT_INTERVAL_MS,
+                ConfigKeys.KAFKA_SOURCE_SESSION_TIMEOUT_MS,
+                ConfigKeys.KAFKA_SOURCE_AUTO_COMMIT_ENABLED
+        );
 
         props = new Properties();
 

--- a/pulsar/src/main/java/org/openconnectors/PulsarSink.java
+++ b/pulsar/src/main/java/org/openconnectors/PulsarSink.java
@@ -4,6 +4,7 @@ import org.apache.pulsar.client.api.MessageId;
 import org.apache.pulsar.client.api.Producer;
 import org.apache.pulsar.client.api.PulsarClient;
 import org.openconnectors.config.Config;
+import org.openconnectors.config.ConfigUtils;
 import org.openconnectors.connect.ConnectorContext;
 import org.openconnectors.connect.SinkConnector;
 import org.slf4j.Logger;
@@ -11,8 +12,6 @@ import org.slf4j.LoggerFactory;
 
 import java.util.Collection;
 import java.util.concurrent.CompletableFuture;
-
-import static org.openconnectors.config.ConfigUtils.verifyExists;
 
 public class PulsarSink implements SinkConnector<byte[]> {
     private static final Logger LOG = LoggerFactory.getLogger(PulsarSink.class);
@@ -45,8 +44,11 @@ public class PulsarSink implements SinkConnector<byte[]> {
 
     @Override
     public void open(Config config) throws Exception {
-        verifyExists(config, PulsarConfigKeys.PULSAR_SINK_TOPIC);
-        verifyExists(config, PulsarConfigKeys.PULSAR_SINK_BROKER_ROOT_URL);
+        ConfigUtils.verifyExists(
+                config,
+                PulsarConfigKeys.PULSAR_SINK_TOPIC,
+                PulsarConfigKeys.PULSAR_SINK_BROKER_ROOT_URL
+        );
 
         String pulsarBrokerRootUrl = config.getString(PulsarConfigKeys.PULSAR_SINK_BROKER_ROOT_URL);
         client = PulsarClient.create(pulsarBrokerRootUrl);

--- a/pulsar/src/main/java/org/openconnectors/PulsarSource.java
+++ b/pulsar/src/main/java/org/openconnectors/PulsarSource.java
@@ -34,7 +34,8 @@ public class PulsarSource implements PushSourceConnector<byte[]> {
 
     @Override
     public void open(Config config) throws Exception {
-        ConfigUtils.verifyExists(config,
+        ConfigUtils.verifyExists(
+                config,
                 PulsarConfigKeys.PULSAR_SOURCE_TOPIC,
                 PulsarConfigKeys.PULSAR_SOURCE_BROKER_ROOT_URL,
                 PulsarConfigKeys.PULSAR_SOURCE_SUBSCRIPTION

--- a/pulsar/src/main/java/org/openconnectors/PulsarSource.java
+++ b/pulsar/src/main/java/org/openconnectors/PulsarSource.java
@@ -4,6 +4,7 @@ import org.apache.pulsar.client.api.Message;
 import org.apache.pulsar.client.api.PulsarClient;
 import org.apache.pulsar.client.api.PulsarClientException;
 import org.openconnectors.config.Config;
+import org.openconnectors.config.ConfigUtils;
 import org.openconnectors.connect.ConnectorContext;
 import org.openconnectors.connect.PushSourceConnector;
 import org.slf4j.Logger;
@@ -12,8 +13,6 @@ import org.slf4j.LoggerFactory;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.function.Consumer;
-
-import static org.openconnectors.config.ConfigUtils.verifyExists;
 
 public class PulsarSource implements PushSourceConnector<byte[]> {
 
@@ -35,10 +34,11 @@ public class PulsarSource implements PushSourceConnector<byte[]> {
 
     @Override
     public void open(Config config) throws Exception {
-
-        verifyExists(config, PulsarConfigKeys.PULSAR_SOURCE_TOPIC);
-        verifyExists(config, PulsarConfigKeys.PULSAR_SOURCE_BROKER_ROOT_URL);
-        verifyExists(config, PulsarConfigKeys.PULSAR_SOURCE_SUBSCRIPTION);
+        ConfigUtils.verifyExists(config,
+                PulsarConfigKeys.PULSAR_SOURCE_TOPIC,
+                PulsarConfigKeys.PULSAR_SOURCE_BROKER_ROOT_URL,
+                PulsarConfigKeys.PULSAR_SOURCE_SUBSCRIPTION
+        );
 
         String pulsarBrokerRootUrl = config.getString(PulsarConfigKeys.PULSAR_SOURCE_BROKER_ROOT_URL);
         client = PulsarClient.create(pulsarBrokerRootUrl);

--- a/twitter/src/main/java/org/openconnectors/twitter/TwitterFireHoseConfigKeys.java
+++ b/twitter/src/main/java/org/openconnectors/twitter/TwitterFireHoseConfigKeys.java
@@ -18,5 +18,5 @@ public class TwitterFireHoseConfigKeys {
 
     public static final String CLIENT_BUFFER_SIZE = "twitter-source.bufferSize";
 
-    public static final String TWITTER_CONNECTOR_VERION = "0.0.1";
+    public static final String TWITTER_CONNECTOR_VERSION = "0.0.1";
 }


### PR DESCRIPTION
This PR adds an easier-to-use `verifyExists` method in `ConfigUtils` that can take multiple strings rather than requiring multiple invocations of `verifyExists`.